### PR TITLE
INT-188: Support for re-scanning a given model version

### DIFF
--- a/hiddenlayer/sdk/constants.py
+++ b/hiddenlayer/sdk/constants.py
@@ -12,3 +12,4 @@ class ScanStatus(str, Enum):
 
 class ApiErrors(str, Enum):
     NON_ADHOC_SENSOR_DELETE = "only adhoc sensors may be deleted"
+    SENSOR_EXISTS = "already exists"

--- a/hiddenlayer/sdk/services/model.py
+++ b/hiddenlayer/sdk/services/model.py
@@ -36,6 +36,24 @@ class ModelAPI:
                 plaintext_name=model_name, version=model_version, adhoc=True
             )
         )
+    
+    def create_or_get(self, *, model_name: str, model_version: Optional[int]) -> Model:
+        """
+        Creates a model in the HiddenLayer Platform if it does not exist.
+        If the model and version already exists, returns the existing model.
+
+        :params model_name: Name of the model
+        :params model_version: Version of the model
+
+        :returns: HiddenLayer ModelID
+        """
+        try:
+            return self.create(model_name=model_name, model_version=model_version)
+        except ApiException as e:
+            if e.status == 400 and str(e.body).find(ApiErrors.SENSOR_EXISTS) != -1:
+                return self.get(model_name=model_name, version=model_version)
+            else:
+                raise e
 
     def get(self, *, model_name: str, version: Optional[int] = None) -> Model:
         """

--- a/hiddenlayer/sdk/services/model.py
+++ b/hiddenlayer/sdk/services/model.py
@@ -36,7 +36,7 @@ class ModelAPI:
                 plaintext_name=model_name, version=model_version, adhoc=True
             )
         )
-    
+
     def create_or_get(self, *, model_name: str, model_version: Optional[int]) -> Model:
         """
         Creates a model in the HiddenLayer Platform if it does not exist.

--- a/hiddenlayer/sdk/services/model_scan.py
+++ b/hiddenlayer/sdk/services/model_scan.py
@@ -70,7 +70,7 @@ class ModelScanAPI:
         file_path = Path(model_path)
 
         filesize = file_path.stat().st_size
-        sensor = self._model_api.create(
+        sensor = self._model_api.create_or_get(
             model_name=model_name, model_version=model_version
         )
         upload = self._sensor_api.begin_multipart_upload(sensor.sensor_id, filesize)

--- a/integration-tests/test_model_scanner.py
+++ b/integration-tests/test_model_scanner.py
@@ -125,6 +125,27 @@ def test_scan_model_multiple_times(tmp_path, hl_client: HiddenlayerServiceClient
     if hl_client.is_saas:
         hl_client.model.delete(model_name=model_name)
 
+def test_rescan_model_with_same_version(tmp_path, hl_client: HiddenlayerServiceClient):
+    """Integration test to rescan a model multiple times with the same verison"""
+
+    model_path = _setup_scan_model(tmp_path)
+    model_name = f"sdk-integration-scan-model-{uuid4()}"
+    model_version = 123
+
+    results: Optional[ScanResults] = None
+    for _ in range(3):
+        results = hl_client.model_scanner.scan_file(
+            model_name=model_name, model_path=model_path, model_version=model_version
+        )
+
+    assert results is not None
+
+    _validate_scan_model(results)
+
+    assert results.inventory.model_version == "123"
+
+    if hl_client.is_saas:
+        hl_client.model.delete(model_name=model_name)
 
 def test_get_sarif_results(tmp_path, hl_client: HiddenlayerServiceClient):
     """Integration test to get sarif results"""
@@ -153,7 +174,6 @@ def test_get_sarif_results(tmp_path, hl_client: HiddenlayerServiceClient):
 
     if hl_client.is_saas:
         hl_client.model.delete(model_name=model_name)
-
 
 def _setup_scan_model(tmp_path):
     model_path = tmp_path / "model.pkl"

--- a/integration-tests/test_model_scanner.py
+++ b/integration-tests/test_model_scanner.py
@@ -125,8 +125,9 @@ def test_scan_model_multiple_times(tmp_path, hl_client: HiddenlayerServiceClient
     if hl_client.is_saas:
         hl_client.model.delete(model_name=model_name)
 
+
 def test_rescan_model_with_same_version(tmp_path, hl_client: HiddenlayerServiceClient):
-    """Integration test to rescan a model multiple times with the same verison"""
+    """Integration test to rescan a model multiple times with the same version"""
 
     model_path = _setup_scan_model(tmp_path)
     model_name = f"sdk-integration-scan-model-{uuid4()}"
@@ -146,6 +147,7 @@ def test_rescan_model_with_same_version(tmp_path, hl_client: HiddenlayerServiceC
 
     if hl_client.is_saas:
         hl_client.model.delete(model_name=model_name)
+
 
 def test_get_sarif_results(tmp_path, hl_client: HiddenlayerServiceClient):
     """Integration test to get sarif results"""
@@ -174,6 +176,7 @@ def test_get_sarif_results(tmp_path, hl_client: HiddenlayerServiceClient):
 
     if hl_client.is_saas:
         hl_client.model.delete(model_name=model_name)
+
 
 def _setup_scan_model(tmp_path):
     model_path = tmp_path / "model.pkl"


### PR DESCRIPTION
Prior to this change, if a user of the SDK submitted a model with the same model name and version, the system would reject it because `sensor with name/ version already exists`

The HiddenLayer platform does in fact allow re-scanning a given model version and our SDK should support that as well.  With this change, the SDK identifies when the sensor already exists and instead of attempting to create the sensor and ending up with the conflict, it uses the existing sensor and submits the model for re-scan
