### PR TITLE
Return sarif as propertly formatted json string

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ copyright = "2024"
 author = "HiddenLayer Integrations Team"
 
 release = "1.2"
-version = "1.2.1"
+version = "1.2.2"
 
 # -- General configuration
 

--- a/hiddenlayer/sdk/services/model_scan.py
+++ b/hiddenlayer/sdk/services/model_scan.py
@@ -407,7 +407,10 @@ class ModelScanAPI:
         response = self._api_client.call_api(*request)
         response.read()
 
-        return response.data  # type: ignore
+        if response.data is None:
+            return None
+
+        return response.data.decode()
 
     def scan_folder(
         self,

--- a/hiddenlayer/sdk/services/model_scan.py
+++ b/hiddenlayer/sdk/services/model_scan.py
@@ -407,6 +407,8 @@ class ModelScanAPI:
         response = self._api_client.call_api(*request)
         response.read()
 
+        return response.data # type: ignore
+
         return self._api_client.response_deserialize(
             response_data=response, response_types_map={"200": str}
         ).data  # type: ignore

--- a/hiddenlayer/sdk/services/model_scan.py
+++ b/hiddenlayer/sdk/services/model_scan.py
@@ -409,10 +409,6 @@ class ModelScanAPI:
 
         return response.data # type: ignore
 
-        return self._api_client.response_deserialize(
-            response_data=response, response_types_map={"200": str}
-        ).data  # type: ignore
-
     def scan_folder(
         self,
         *,

--- a/hiddenlayer/sdk/services/model_scan.py
+++ b/hiddenlayer/sdk/services/model_scan.py
@@ -407,7 +407,7 @@ class ModelScanAPI:
         response = self._api_client.call_api(*request)
         response.read()
 
-        return response.data # type: ignore
+        return response.data  # type: ignore
 
     def scan_folder(
         self,

--- a/hiddenlayer/sdk/version.py
+++ b/hiddenlayer/sdk/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.2.1"
+VERSION = "1.2.2"

--- a/integration-tests/test_model_scanner.py
+++ b/integration-tests/test_model_scanner.py
@@ -165,6 +165,7 @@ def test_get_sarif_results(tmp_path, hl_client: HiddenlayerServiceClient):
     print(sarif_results_str)
 
     assert sarif_results_str is not None
+    assert isinstance(sarif_results_str, str)
 
     # Note: The generated code is not fully able to handle the Sarif model. Not all properties are deserialized
     sarif_results = Sarif.from_json(sarif_results_str)

--- a/integration-tests/test_model_scanner.py
+++ b/integration-tests/test_model_scanner.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import pytest
 
 from hiddenlayer import HiddenlayerServiceClient
-from hiddenlayer.sdk.models import ScanResults
+from hiddenlayer.sdk.models import Sarif, ScanResults
 
 params = [
     ("https://api.us.hiddenlayer.ai"),
@@ -161,19 +161,36 @@ def test_get_sarif_results(tmp_path, hl_client: HiddenlayerServiceClient):
 
     _validate_scan_model(results)
 
-    sarif_results = hl_client.model_scanner.get_sarif_results(model_name=model_name)
-    print(sarif_results)
+    sarif_results_str = hl_client.model_scanner.get_sarif_results(model_name=model_name)
+    print(sarif_results_str)
 
-    # TODO: Loop back to think about adding asserts
-    # assert sarif_results is not None
-    # assert sarif_results.version == "2.1.0"
-    # assert sarif_results.runs is not None
-    # run = sarif_results.runs[0]
-    # assert run.tool.driver.name == "HiddenLayer Model Scanner"
-    # assert run.results is not None
-    # results = run.results[0]
-    # assert results.level == "error"
-    # assert results.rule_id == "PICKLE_0017_202408"
+    assert sarif_results_str is not None
+
+    # Note: The generated code is not fully able to handle the Sarif model. Not all properties are deserialized
+    sarif_results = Sarif.from_json(sarif_results_str)
+    assert sarif_results is not None
+
+    assert sarif_results.version == "2.1.0"
+    assert sarif_results.runs is not None
+    run = sarif_results.runs[0]
+    assert run.tool.driver.name == "HiddenLayer Model Scanner"
+    assert run.results is not None
+    results = run.results[0]
+    assert results.level == "error"
+    assert results.rule_id == "PICKLE_0017_202408"
+    assert results.message is not None
+    # results.message.text does not deserialize correctly due to anyOf
+    # assert results.message.text == "This detection rule was triggered by the presence of a function or library that can be used to execute code. Offending module / function:eval / exec / system."
+    assert results.locations is not None
+    assert results.locations[0].physical_location is not None
+
+    # results.locations[0].physical_location does not deserialize correctly due to anyOf
+    # assert results.locations[0].physical_location.artifact_location is not None
+    # assert results.locations[0].physical_location.artifact_location.uri == "Local%20Model%20Upload/malicious_model.pkl"
+
+    # test roundtrip
+    sarif_results_str = sarif_results.model_dump_json(indent=4, exclude_none=True)
+    print(sarif_results_str)
 
     if hl_client.is_saas:
         hl_client.model.delete(model_name=model_name)


### PR DESCRIPTION
## Describe your changes

This PR:
* ensures the result returned is a properly formatted json string (double-quotes, not single-quotes)
* adds tests for the output using the Sarif model

**Note**
The Sarif model does not correctly deserialize all properties.  It appears the generated Python code has issues with some of the properties that use `anyOf` and does not deserialize them properly.

see https://github.com/OpenAPITools/openapi-generator/issues/19015 and https://github.com/OpenAPITools/openapi-generator/issues/16110

