### PR TITLE
INT-243: fix release pipeline

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -29,6 +29,39 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e '.[dev]'
+    - name: Login to Quay
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      with:
+        registry: quay.io
+        username: ${{ vars.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_TOKEN }}
+    - name: Set up K8s kind cluster
+      uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+      with:
+        config: integration-tests/enterprise-modscan/kind.yaml
+    - name: Set up Enterprise Model Scanner
+      run: |
+          curl https://dl.min.io/client/mc/release/linux-amd64/mc \
+            --create-dirs \
+            -o $HOME/minio-binaries/mc
+  
+          chmod +x $HOME/minio-binaries/mc
+          export PATH=$PATH:$HOME/minio-binaries/
+  
+          mc --help
+  
+          make setup-enterprise-modscan
+          sleep 60
+          kubectl get pods --namespace=hl-modelscanner
+          make port-forward-service
+          make setup-s3-dns
+          make add-minio-bucket
+          sleep 5
+          curl http://localhost:8000/health
+      env:
+        QUAY_USERNAME: ${{ vars.QUAY_USERNAME }}
+        QUAY_PASSWORD: ${{ secrets.QUAY_TOKEN }}
+        HL_LICENSE: ${{ secrets.HL_LICENSE }}
     - name: Run tests
       run: |
         pytest

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ copyright = "2024"
 author = "HiddenLayer Integrations Team"
 
 release = "2.0"
-version = "2.0.0"
+version = "2.0.1"
 
 # -- General configuration
 

--- a/hiddenlayer/sdk/version.py
+++ b/hiddenlayer/sdk/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.0.0"
+VERSION = "2.0.1"


### PR DESCRIPTION
## Describe your changes

Now that we are testing against enterprise model scanner, the release pipeline also needs to set up a running enterprise model scanner to test against.

## Issue ticket number and link
