### PR TITLE
Remove validation of file_type in file details structure

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ copyright = "2024"
 author = "HiddenLayer Integrations Team"
 
 release = "2.0"
-version = "2.0.1"
+version = "2.0.2"
 
 # -- General configuration
 

--- a/hiddenlayer/sdk/rest/models/file_details_v3.py
+++ b/hiddenlayer/sdk/rest/models/file_details_v3.py
@@ -74,13 +74,6 @@ class FileDetailsV3(BaseModel):
             raise ValueError(r"must validate the regular expression /^\d+(\.\d+)?\s?(B|KB|MB|GB|TB)$/")
         return value
 
-    @field_validator('file_type')
-    def file_type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['safetensors', 'RDS', 'onnx', 'tensorflow', 'keras', 'pytorch', 'pickle', 'NEMO', 'numpy', 'unknown', 'ZIP', 'TAR', 'gguf']):
-            raise ValueError("must be one of enum values ('safetensors', 'RDS', 'onnx', 'tensorflow', 'keras', 'pytorch', 'pickle', 'NEMO', 'numpy', 'unknown', 'ZIP', 'TAR', 'gguf')")
-        return value
-
     model_config = ConfigDict(
         populate_by_name=True,
         validate_assignment=True,

--- a/hiddenlayer/sdk/version.py
+++ b/hiddenlayer/sdk/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.0.1"
+VERSION = "2.0.2"


### PR DESCRIPTION
## Describe your changes

Update SDK based of updates to the main openapi spec. file_type field is no longer constrained to a list of enum values.

## Issue ticket number and link

INT-286