### PR TITLE
Don't require sha256 or allow it to be empty (failed files)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ copyright = "2024"
 author = "HiddenLayer Integrations Team"
 
 release = "2.0"
-version = "2.0.7"
+version = "2.0.8"
 
 # -- General configuration
 

--- a/hiddenlayer/sdk/rest/api/model_supply_chain_api.py
+++ b/hiddenlayer/sdk/rest/api/model_supply_chain_api.py
@@ -2392,7 +2392,7 @@ class ModelSupplyChainApi:
     @validate_call
     def get_scan_results1(
         self,
-        scan_id: Optional[StrictStr] = None,
+        scan_id: StrictStr,
         cursor: Optional[StrictStr] = None,
         page_size: Optional[Annotated[int, Field(strict=True, ge=1)]] = None,
         _request_timeout: Union[
@@ -2411,7 +2411,7 @@ class ModelSupplyChainApi:
         """Retrieve Model Scan Results
 
 
-        :param scan_id:
+        :param scan_id: (required)
         :type scan_id: str
         :param cursor:
         :type cursor: str
@@ -2469,7 +2469,7 @@ class ModelSupplyChainApi:
     @validate_call
     def get_scan_results1_with_http_info(
         self,
-        scan_id: Optional[StrictStr] = None,
+        scan_id: StrictStr,
         cursor: Optional[StrictStr] = None,
         page_size: Optional[Annotated[int, Field(strict=True, ge=1)]] = None,
         _request_timeout: Union[
@@ -2488,7 +2488,7 @@ class ModelSupplyChainApi:
         """Retrieve Model Scan Results
 
 
-        :param scan_id:
+        :param scan_id: (required)
         :type scan_id: str
         :param cursor:
         :type cursor: str
@@ -2546,7 +2546,7 @@ class ModelSupplyChainApi:
     @validate_call
     def get_scan_results1_without_preload_content(
         self,
-        scan_id: Optional[StrictStr] = None,
+        scan_id: StrictStr,
         cursor: Optional[StrictStr] = None,
         page_size: Optional[Annotated[int, Field(strict=True, ge=1)]] = None,
         _request_timeout: Union[
@@ -2565,7 +2565,7 @@ class ModelSupplyChainApi:
         """Retrieve Model Scan Results
 
 
-        :param scan_id:
+        :param scan_id: (required)
         :type scan_id: str
         :param cursor:
         :type cursor: str

--- a/hiddenlayer/sdk/rest/docs/ModelSupplyChainApi.md
+++ b/hiddenlayer/sdk/rest/docs/ModelSupplyChainApi.md
@@ -669,7 +669,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_scan_results1**
-> List[ScanResultsMapV3] get_scan_results1(scan_id=scan_id, cursor=cursor, page_size=page_size)
+> List[ScanResultsMapV3] get_scan_results1(scan_id, cursor=cursor, page_size=page_size)
 
 Retrieve Model Scan Results
 
@@ -703,13 +703,13 @@ configuration = hiddenlayer.sdk.rest.Configuration(
 with hiddenlayer.sdk.rest.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = hiddenlayer.sdk.rest.ModelSupplyChainApi(api_client)
-    scan_id = 'scan_id_example' # str |  (optional)
+    scan_id = 'scan_id_example' # str | 
     cursor = 'cursor_example' # str |  (optional)
     page_size = 25 # int |  (optional) (default to 25)
 
     try:
         # Retrieve Model Scan Results
-        api_response = api_instance.get_scan_results1(scan_id=scan_id, cursor=cursor, page_size=page_size)
+        api_response = api_instance.get_scan_results1(scan_id, cursor=cursor, page_size=page_size)
         print("The response of ModelSupplyChainApi->get_scan_results1:\n")
         pprint(api_response)
     except Exception as e:
@@ -723,7 +723,7 @@ with hiddenlayer.sdk.rest.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **scan_id** | **str**|  | [optional] 
+ **scan_id** | **str**|  | 
  **cursor** | **str**|  | [optional] 
  **page_size** | **int**|  | [optional] [default to 25]
 

--- a/hiddenlayer/sdk/rest/models/file_details_v3.py
+++ b/hiddenlayer/sdk/rest/models/file_details_v3.py
@@ -50,8 +50,8 @@ class FileDetailsV3(BaseModel):
     @field_validator('sha256')
     def sha256_validate_regular_expression(cls, value):
         """Validates the regular expression"""
-        if not re.match(r"^[a-fA-F0-9]{64}$", value):
-            raise ValueError(r"must validate the regular expression /^[a-fA-F0-9]{64}$/")
+        if not re.match(r"^$|^[a-fA-F0-9]{64}$", value):
+            raise ValueError(r"must validate the regular expression /^$|^[a-fA-F0-9]{64}$/")
         return value
 
     @field_validator('tlsh')

--- a/hiddenlayer/sdk/version.py
+++ b/hiddenlayer/sdk/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.0.7"
+VERSION = "2.0.8"


### PR DESCRIPTION
## Describe your changes

Allow modscan file details to either not provide a sha256 or have it be an empty string.  This is to support failed files where there is no sha256 calculated

## Issue ticket number and link
