### PR TITLE
docs: add RedTeamSessions to API reference

### DIFF
--- a/api.md
+++ b/api.md
@@ -223,12 +223,11 @@ Accessed via `client.evaluation_sessions.red_team`.
 
 Methods:
 
-- **start_session(name, target_model, objective_ids=None, target_system_prompt="", refusal_judge_model=None, objective_judge_model=None, attacker_model=None, evaluation_report_model=None, max_turns=3, execution_strategy_type="random", attacker_max_generation_attempts=2, n_random_techniques=1, max_parallel_techniques=1, prompt_set_id="", hiddenlayer_project_id=None, poll_interval=2.0, poll_max_wait=None, sessions_per_technique=1) -> RedTeamSession**  
+- **start_session(name, target_model, target_system_prompt="", max_turns=3, execution_strategy_type="random", attacker_max_generation_attempts=2, n_random_techniques=1, max_parallel_techniques=1, prompt_set_id="", hiddenlayer_project_id=None, poll_interval=2.0, poll_max_wait=None, sessions_per_technique=1) -> RedTeamSession**  
   Start a new red team session. Returns a `RedTeamSession` (sync) or `AsyncRedTeamSession` (async).
   Uses adaptive multi-objective evaluation: each session runs to `max_turns` (no short-circuit),
-  tests all provided objectives, and maintains cross-session state for adaptive attacks.
+  tests all objectives, and maintains cross-session state for adaptive attacks.
   `sessions_per_technique` controls how many sessions run per technique (default 1).
-  When `objective_ids` is None, defaults to all available objectives.
 
 - **resume_session(workflow_id, poll_interval=2.0, poll_max_wait=None, max_parallel_techniques=None) -> RedTeamSession**  
   Reconnect to a previously started workflow by its ID.
@@ -287,18 +286,6 @@ from hiddenlayer.lib.red_team_exceptions import (
 - **PollTimeoutError** -- Raised when polling exceeds `max_wait`.
 - **WorkflowNotFoundError** -- Raised when a workflow ID does not exist (HTTP 404).
 - **InvalidSessionError** -- Raised when a session ID is invalid during response submission (HTTP 400).
-
-### Objective IDs
-
-Available objective IDs that can be passed to `start_session(objective_ids=...)`:
-
-| ID | Category |
-|----|----------|
-| `HLO.01` | Alignment Bypass / Jailbreak |
-| `HLO.02` | Task Redirection / Hijacking |
-| `HLO.03` | Context Leakage |
-| `HLO.05` | Data Leakage |
-| `HLO.07` | Reputation Damage |
 
 ### Execution Strategies
 

--- a/api.md
+++ b/api.md
@@ -203,6 +203,111 @@ CommunityScanSource.GOOGLE_OAUTH = "GOOGLE_OAUTH"
 CommunityScanSource.HUGGING_FACE = "HUGGING_FACE"
 ```
 
+## RedTeamSessions
+
+High-level session management for red team evaluations. Wraps the low-level `client.evaluations.red_team.*` API into a stateful session abstraction with polling, iteration, and callback-driven execution.
+
+```python
+from hiddenlayer.lib import EvaluationSessionsResource, AsyncEvaluationSessionsResource
+from hiddenlayer.lib.red_team_exceptions import (
+    RedTeamSessionError,
+    PollTimeoutError,
+    WorkflowNotFoundError,
+    InvalidSessionError,
+)
+```
+
+### Session Manager
+
+Accessed via `client.evaluation_sessions.red_team`.
+
+Methods:
+
+- **start_session(name, target_model, objective_ids=None, target_system_prompt="", refusal_judge_model=None, objective_judge_model=None, attacker_model=None, evaluation_report_model=None, max_turns=3, execution_strategy_type="random", attacker_max_generation_attempts=2, n_random_techniques=1, max_parallel_techniques=1, prompt_set_id="", hiddenlayer_project_id=None, poll_interval=2.0, poll_max_wait=None, sessions_per_technique=1) -> RedTeamSession**  
+  Start a new red team session. Returns a `RedTeamSession` (sync) or `AsyncRedTeamSession` (async).
+  Uses adaptive multi-objective evaluation: each session runs to `max_turns` (no short-circuit),
+  tests all provided objectives, and maintains cross-session state for adaptive attacks.
+  `sessions_per_technique` controls how many sessions run per technique (default 1).
+  When `objective_ids` is None, defaults to all available objectives.
+
+- **resume_session(workflow_id, poll_interval=2.0, poll_max_wait=None, max_parallel_techniques=None) -> RedTeamSession**  
+  Reconnect to a previously started workflow by its ID.
+
+- **terminate_session(workflow_id) -> None**  
+  Stop a running workflow.
+
+### Session Object
+
+Returned by `start_session()` and `resume_session()`. Available as `RedTeamSession` (sync) and `AsyncRedTeamSession` (async).
+
+Properties:
+
+- **workflow_id -> str**  
+  The workflow ID for this session.
+
+- **name -> str**  
+  The session name.
+
+Methods:
+
+- **get_next_action(block=True) -> RedTeamRetrieveNextActionResponse**  
+  Poll the server for the next action. When `block=True`, waits until an action is ready.
+
+- **wait_for_completion(poll_interval=3.0, max_wait=300.0, verbose=False) -> None**  
+  Poll status until the workflow reaches a terminal state (COMPLETED, FAILED, CANCELLED, TERMINATED, or TIMED_OUT). Automatically called by `run_with_callback()` and `run_with_callback_parallel()`.
+
+- **iterate_actions() -> Iterator[RedTeamRetrieveNextActionResponse]**  
+  Yield `attack_task` actions until the workflow completes or fails. Use with `for`/`async for`.
+
+- **run_with_callback(handler) -> None**  
+  Drive the full session sequentially. The handler receives `(attack_prompt, history, session_id, target_system_prompt)` and returns the target model's response string. Waits for workflow completion before returning.
+
+### Async-Only Session Methods
+
+These methods are only available on `AsyncRedTeamSession`:
+
+- **get_available_actions(max_actions=10) -> list[RedTeamRetrieveNextActionResponse]**  
+  Non-blocking batch fetch of up to `max_actions` currently ready actions.
+
+- **run_with_callback_parallel(handler, max_parallel=None, poll_batch_interval=0.5) -> None**  
+  Drive the session with parallel action processing. When `max_parallel` is None, uses the `max_parallel_techniques` value from session config.
+
+### Exceptions
+
+```python
+from hiddenlayer.lib.red_team_exceptions import (
+    RedTeamSessionError,
+    PollTimeoutError,
+    WorkflowNotFoundError,
+    InvalidSessionError,
+)
+```
+
+- **RedTeamSessionError** -- Base exception for red team session errors.
+- **PollTimeoutError** -- Raised when polling exceeds `max_wait`.
+- **WorkflowNotFoundError** -- Raised when a workflow ID does not exist (HTTP 404).
+- **InvalidSessionError** -- Raised when a session ID is invalid during response submission (HTTP 400).
+
+### Objective IDs
+
+Available objective IDs that can be passed to `start_session(objective_ids=...)`:
+
+| ID | Category |
+|----|----------|
+| `HLO.01` | Alignment Bypass / Jailbreak |
+| `HLO.02` | Task Redirection / Hijacking |
+| `HLO.03` | Context Leakage |
+| `HLO.05` | Data Leakage |
+| `HLO.07` | Reputation Damage |
+
+### Execution Strategies
+
+Available values for `start_session(execution_strategy_type=...)`:
+
+- `"single"` -- Single technique execution
+- `"random"` -- Random technique selection (default)
+- `"static_prompt_set"` -- Static prompt set evaluation (requires `prompt_set_id`)
+
 # Client Usage
 
 ## Authentication Methods

--- a/src/hiddenlayer/lib/red_team_session.py
+++ b/src/hiddenlayer/lib/red_team_session.py
@@ -253,23 +253,14 @@ class RedTeamSessionsResource(SyncAPIResource):
     ) -> RedTeamSession:
         """Start a new red team session.
 
-        Supports two modes:
-
-        V1 Mode (objective-specific with short-circuit):
-            - Provide objective_ids (required)
-            - Do not set sessions_per_technique
-            - Each session tests one objective and short-circuits on success
-
-        V2 Mode (objective-agnostic adaptive):
-            - Set sessions_per_technique (e.g., 3)
-            - objective_ids optional (defaults to all available)
-            - Each session tests all objectives, runs to max_turns
-            - Adaptive attacker with cross-session state
+        Uses adaptive multi-objective evaluation: each session runs to
+        max_turns (no short-circuit), tests all provided objectives, and
+        maintains cross-session state for adaptive attacks.
 
         Args:
             name: Session name
-            objective_ids: List of objective IDs to test (e.g., ["HLO.03"])
-                V1: Required. V2: Optional (defaults to all available)
+            objective_ids: List of objective IDs to test (e.g., ["HLO.03"]).
+                Optional; defaults to all available objectives.
             target_model: Model identifier for the target being tested
             target_system_prompt: System prompt for the target model
             refusal_judge_model: Model to use for refusal judging
@@ -288,13 +279,13 @@ class RedTeamSessionsResource(SyncAPIResource):
             hiddenlayer_project_id: Optional HiddenLayer project ID
             poll_interval: How often to poll for actions (seconds, default: 2.0s)
             poll_max_wait: Maximum time to wait for actions (seconds)
-            sessions_per_technique: Number of sessions to run per technique (enables V2 mode)
+            sessions_per_technique: Number of sessions to run per technique
 
         Returns:
-            AsyncRedTeamSession instance
+            RedTeamSession instance
 
         Raises:
-            ValueError: If objective_ids not provided in V1 mode
+            ValueError: If execution_strategy_type is invalid
         """
         # Use defaults if not provided
         refusal_judge_model = refusal_judge_model or self._default_refusal_judge_model
@@ -302,7 +293,7 @@ class RedTeamSessionsResource(SyncAPIResource):
         attacker_model = attacker_model or self._default_attacker_model
         evaluation_report_model = evaluation_report_model or self._default_evaluation_report_model
 
-        # V2 mode: objective_ids optional (defaults to all)
+        # Default to all available objectives if not specified
         if objective_ids is None:
             objective_ids = self._available_objective_ids.copy()
 
@@ -791,23 +782,14 @@ class AsyncRedTeamSessionsResource(AsyncAPIResource):
     ) -> AsyncRedTeamSession:
         """Start a new red team session.
 
-        Supports two modes:
-
-        V1 Mode (objective-specific with short-circuit):
-            - Provide objective_ids (required)
-            - Do not set sessions_per_technique
-            - Each session tests one objective and short-circuits on success
-
-        V2 Mode (objective-agnostic adaptive):
-            - Set sessions_per_technique (e.g., 3)
-            - objective_ids optional (defaults to all available)
-            - Each session tests all objectives, runs to max_turns
-            - Adaptive attacker with cross-session state
+        Uses adaptive multi-objective evaluation: each session runs to
+        max_turns (no short-circuit), tests all provided objectives, and
+        maintains cross-session state for adaptive attacks.
 
         Args:
             name: Session name
-            objective_ids: List of objective IDs to test (e.g., ["HLO.03"])
-                V1: Required. V2: Optional (defaults to all available)
+            objective_ids: List of objective IDs to test (e.g., ["HLO.03"]).
+                Optional; defaults to all available objectives.
             target_model: Model identifier for the target being tested
             target_system_prompt: System prompt for the target model
             refusal_judge_model: Model to use for refusal judging
@@ -826,13 +808,13 @@ class AsyncRedTeamSessionsResource(AsyncAPIResource):
             hiddenlayer_project_id: Optional HiddenLayer project ID
             poll_interval: How often to poll for actions (seconds, default: 2.0s)
             poll_max_wait: Maximum time to wait for actions (seconds)
-            sessions_per_technique: Number of sessions to run per technique (enables V2 mode)
+            sessions_per_technique: Number of sessions to run per technique
 
         Returns:
             AsyncRedTeamSession instance
 
         Raises:
-            ValueError: If objective_ids not provided in V1 mode
+            ValueError: If execution_strategy_type is invalid
         """
         # Use defaults if not provided
         refusal_judge_model = refusal_judge_model or self._default_refusal_judge_model
@@ -840,7 +822,7 @@ class AsyncRedTeamSessionsResource(AsyncAPIResource):
         attacker_model = attacker_model or self._default_attacker_model
         evaluation_report_model = evaluation_report_model or self._default_evaluation_report_model
 
-        # V2 mode: objective_ids optional (defaults to all)
+        # Default to all available objectives if not specified
         if objective_ids is None:
             objective_ids = self._available_objective_ids.copy()
 


### PR DESCRIPTION
## Summary

- Add the `RedTeamSessions` library extension to `api.md`, documenting the high-level session management layer that wraps `client.evaluations.red_team.*` into a stateful session abstraction
- Remove obsolete V1/V2 mode references from `start_session()` docstrings in `red_team_session.py` -- V1 mode is no longer supported by the backend service

## What's documented

- **Session Manager** (`client.evaluation_sessions.red_team`): `start_session`, `resume_session`, `terminate_session`
- **Session Object** (`RedTeamSession` / `AsyncRedTeamSession`): properties, `get_next_action`, `wait_for_completion`, `iterate_actions`, `run_with_callback`
- **Async-only methods**: `get_available_actions`, `run_with_callback_parallel`
- **Exception types**: `RedTeamSessionError`, `PollTimeoutError`, `WorkflowNotFoundError`, `InvalidSessionError`
