### PR TITLE
fix(client/oauth): update token request to use body grant type and ad…

### DIFF
--- a/src/hiddenlayer/_client.py
+++ b/src/hiddenlayer/_client.py
@@ -233,7 +233,7 @@ class HiddenLayer(SyncAPIClient):
             return make_oauth2(
                 client_id=self.client_id,
                 client_secret=self.client_secret,
-                token_url=self._prepare_url("/oauth2/token?grant_type=client_credentials"),
+                token_url=self._prepare_url("/oauth2/token"),
                 header="Authorization",
             )
         return None
@@ -520,7 +520,7 @@ class AsyncHiddenLayer(AsyncAPIClient):
             return make_oauth2(
                 client_id=self.client_id,
                 client_secret=self.client_secret,
-                token_url=self._prepare_url("/oauth2/token?grant_type=client_credentials"),
+                token_url=self._prepare_url("/oauth2/token"),
                 header="Authorization",
             )
         return None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -714,7 +714,7 @@ class TestHiddenLayer:
 
         auth = client.custom_auth
         assert auth is not None
-        request = auth._build_token_request()
+        request = cast(httpx.Request, cast(Any, auth)._build_token_request())
 
         assert str(request.url) == "https://api.hiddenlayer.ai/oauth2/token"
         assert request.content == b"grant_type=client_credentials"
@@ -1676,7 +1676,7 @@ class TestAsyncHiddenLayer:
 
         auth = client.custom_auth
         assert auth is not None
-        request = auth._build_token_request()
+        request = cast(httpx.Request, cast(Any, auth)._build_token_request())
 
         assert str(request.url) == "https://api.hiddenlayer.ai/oauth2/token"
         assert request.content == b"grant_type=client_credentials"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -704,6 +704,24 @@ class TestHiddenLayer:
 
             client.close()
 
+    def test_oauth_token_request_uses_body_grant_type(self) -> None:
+        client = HiddenLayer(
+            base_url="https://api.hiddenlayer.ai",
+            client_id="client-id",
+            client_secret="client-secret",
+            _strict_response_validation=True,
+        )
+
+        auth = client.custom_auth
+        assert auth is not None
+        request = auth._build_token_request()
+
+        assert str(request.url) == "https://api.hiddenlayer.ai/oauth2/token"
+        assert request.content == b"grant_type=client_credentials"
+        assert "grant_type=" not in str(request.url)
+
+        client.close()
+
     @pytest.mark.parametrize(
         "client",
         [
@@ -1647,6 +1665,24 @@ class TestAsyncHiddenLayer:
             assert str(client.base_url).startswith("https://api.hiddenlayer.ai")
 
             await client.close()
+
+    async def test_oauth_token_request_uses_body_grant_type(self) -> None:
+        client = AsyncHiddenLayer(
+            base_url="https://api.hiddenlayer.ai",
+            client_id="client-id",
+            client_secret="client-secret",
+            _strict_response_validation=True,
+        )
+
+        auth = client.custom_auth
+        assert auth is not None
+        request = auth._build_token_request()
+
+        assert str(request.url) == "https://api.hiddenlayer.ai/oauth2/token"
+        assert request.content == b"grant_type=client_credentials"
+        assert "grant_type=" not in str(request.url)
+
+        await client.close()
 
     @pytest.mark.parametrize(
         "client",


### PR DESCRIPTION

## Describe your changes
Modified the OAuth2 token request to send the grant_type as part of the request body instead of the URL. Added unit tests for both synchronous and asynchronous clients to verify the correct behavior of the token request.