### PR TITLE
feat: add beta instability warnings for unstable SDK methods

### DIFF
--- a/.github/workflows/patch-beta-warnings.yml
+++ b/.github/workflows/patch-beta-warnings.yml
@@ -1,0 +1,34 @@
+name: Patch Beta Warnings
+
+on:
+  push:
+    branches:
+      - next
+
+jobs:
+  patch:
+    timeout-minutes: 5
+    name: patch-beta-warnings
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run beta warning patcher
+        run: node scripts/utils/patch-beta-warnings.cjs
+
+      - name: Commit changes
+        run: |
+          git diff --quiet && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: patch beta warnings [skip ci]"
+          git push

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ xfail_strict = true
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 filterwarnings = [
+  "default::hiddenlayer.lib._beta.BetaWarning",
   "error"
 ]
 

--- a/scripts/utils/patch-beta-warnings.cjs
+++ b/scripts/utils/patch-beta-warnings.cjs
@@ -1,0 +1,217 @@
+// @ts-check
+const fs = require('fs');
+const path = require('path');
+
+const resourcesDir = path.resolve(__dirname, '..', '..', 'src', 'hiddenlayer', 'resources');
+
+/**
+ * Recursively walk a directory yielding file paths.
+ */
+async function* walk(dir) {
+  for await (const d of await fs.promises.opendir(dir)) {
+    const entry = path.join(dir, d.name);
+    if (d.isDirectory()) yield* walk(entry);
+    else if (d.isFile()) yield entry;
+  }
+}
+
+/**
+ * Compute the relative import path from a resource file to the lib._beta module.
+ * e.g. resources/scans/jobs.py (depth 2) → "...lib._beta"
+ */
+function computeImportPrefix(filePath) {
+  const rel = path.relative(resourcesDir, filePath);
+  // Count directory separators to determine depth
+  const depth = rel.split(path.sep).length; // file itself counts as 1
+  // From resources/foo.py we need "..lib._beta" (2 dots = up to package root)
+  // From resources/scans/jobs.py we need "...lib._beta" (3 dots)
+  return '.'.repeat(depth + 1);
+}
+
+/**
+ * Extract class names that extend SyncAPIResource or AsyncAPIResource.
+ */
+function extractClassNames(content) {
+  const classes = [];
+  const pattern = /class\s+(\w+)\((Sync|Async)APIResource\)/g;
+  let match;
+  while ((match = pattern.exec(content)) !== null) {
+    classes.push(match[1]);
+  }
+  return classes;
+}
+
+/**
+ * Patch a single resource file: insert or remove warn_beta calls
+ * based on whether methods have [BETA] in their docstrings.
+ *
+ * Returns the (possibly modified) content, or null if no changes needed.
+ */
+function patchFile(content, filePath) {
+  const classNames = extractClassNames(content);
+  if (classNames.length === 0) return null;
+
+  // Build a map of class name → line range so we can attribute methods to classes
+  const classRanges = [];
+  for (const className of classNames) {
+    const classPattern = new RegExp(`class\\s+${className}\\(`);
+    const match = classPattern.exec(content);
+    if (match) {
+      classRanges.push({ name: className, start: match.index });
+    }
+  }
+  classRanges.sort((a, b) => a.start - b.start);
+
+  // Find all method definitions with their docstrings.
+  // Pattern: "def methodname(" followed eventually by a docstring (triple-quoted)
+  const methodPattern =
+    /( +)def\s+(\w+)\s*\([^)]*\)[^:]*:\s*\n\s+"""([\s\S]*?)"""/g;
+
+  const edits = [];
+  let match;
+
+  while ((match = methodPattern.exec(content)) !== null) {
+    const indent = match[1];
+    const methodName = match[2];
+    const docstring = match[3];
+    const fullMatch = match[0];
+    const matchEnd = match.index + fullMatch.length;
+
+    // Skip private/dunder methods and property accessors
+    if (methodName.startsWith('_')) continue;
+    if (methodName === 'with_raw_response' || methodName === 'with_streaming_response')
+      continue;
+
+    // Determine which class this method belongs to
+    let className = null;
+    for (let i = classRanges.length - 1; i >= 0; i--) {
+      if (match.index > classRanges[i].start) {
+        className = classRanges[i].name;
+        break;
+      }
+    }
+    if (!className) continue;
+
+    const qualifiedName = `${className}.${methodName}`;
+    const warnCall = `warn_beta("${qualifiedName}")`;
+    const isBeta = docstring.includes('[BETA]');
+
+    if (isBeta && !content.includes(warnCall)) {
+      // Insert warn_beta call after the closing """
+      const bodyIndent = indent + '    ';
+      edits.push({
+        type: 'insert',
+        index: matchEnd,
+        text: '\n' + bodyIndent + warnCall,
+      });
+    } else if (!isBeta) {
+      // Remove any existing warn_beta call for this method
+      const warnPattern = new RegExp(
+        `\\n\\s*warn_beta\\("${escapeRegExp(qualifiedName)}"\\)`,
+      );
+      const warnMatch = content.match(warnPattern);
+      if (warnMatch && warnMatch.index !== undefined) {
+        edits.push({
+          type: 'remove',
+          index: warnMatch.index,
+          length: warnMatch[0].length,
+        });
+      }
+    }
+  }
+
+  if (edits.length === 0) {
+    return manageImport(content, filePath);
+  }
+
+  // Apply edits bottom-up
+  edits.sort((a, b) => (b.index || 0) - (a.index || 0));
+  let modified = content;
+  for (const edit of edits) {
+    if (edit.type === 'insert') {
+      modified =
+        modified.slice(0, edit.index) + edit.text + modified.slice(edit.index);
+    } else if (edit.type === 'remove') {
+      modified =
+        modified.slice(0, edit.index) +
+        modified.slice(edit.index + edit.length);
+    }
+  }
+
+  // Manage import
+  const result = manageImport(modified, filePath);
+  return result !== null ? result : modified !== content ? modified : null;
+}
+
+/**
+ * Add or remove the warn_beta import as needed.
+ */
+function manageImport(content, filePath) {
+  const hasAnyCalls = /warn_beta\(/.test(content);
+  const importPrefix = computeImportPrefix(filePath);
+  const importStatement = `from ${importPrefix}lib._beta import warn_beta`;
+  const hasImport = content.includes('warn_beta') && content.includes('from') && /from\s+\.+lib\._beta\s+import\s+warn_beta/.test(content);
+
+  let modified = content;
+
+  if (hasAnyCalls && !hasImport) {
+    // Add import after the last existing import line
+    const importPattern = /^from\s.+import\s.+$/gm;
+    let lastIndex = -1;
+    let m;
+    while ((m = importPattern.exec(modified)) !== null) {
+      lastIndex = m.index + m[0].length;
+    }
+    if (lastIndex !== -1) {
+      modified =
+        modified.slice(0, lastIndex) +
+        '\n' +
+        importStatement +
+        modified.slice(lastIndex);
+    }
+  } else if (!hasAnyCalls && hasImport) {
+    modified = modified.replace(
+      new RegExp(`\\nfrom\\s+\\.+lib\\._beta\\s+import\\s+warn_beta`),
+      '',
+    );
+  }
+
+  return modified !== content ? modified : null;
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function main() {
+  let patchedCount = 0;
+
+  for await (const filePath of walk(resourcesDir)) {
+    if (!filePath.endsWith('.py')) continue;
+    if (path.basename(filePath) === '__init__.py') continue;
+
+    const content = await fs.promises.readFile(filePath, 'utf8');
+
+    // Skip files without resource classes
+    if (
+      !content.includes('SyncAPIResource') &&
+      !content.includes('AsyncAPIResource')
+    )
+      continue;
+
+    const patched = patchFile(content, filePath);
+    if (patched !== null) {
+      await fs.promises.writeFile(filePath, patched, 'utf8');
+      const rel = path.relative(process.cwd(), filePath);
+      console.log(`patched ${rel}`);
+      patchedCount++;
+    }
+  }
+
+  console.log(`\n${patchedCount} file(s) patched.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/hiddenlayer/__init__.py
+++ b/src/hiddenlayer/__init__.py
@@ -5,11 +5,11 @@ import typing as _t
 from . import types
 from .lib import (
     BetaWarning,
-    warn_beta,
     ModelScanner,
     CommunityScanner,
     AsyncModelScanner,
     AsyncCommunityScanner,
+    warn_beta,
 )
 from ._types import NOT_GIVEN, Omit, NoneType, NotGiven, Transport, ProxiesTypes, omit, not_given
 from ._utils import file_from_path

--- a/src/hiddenlayer/__init__.py
+++ b/src/hiddenlayer/__init__.py
@@ -3,7 +3,14 @@
 import typing as _t
 
 from . import types
-from .lib import ModelScanner, CommunityScanner, AsyncModelScanner, AsyncCommunityScanner
+from .lib import (
+    BetaWarning,
+    warn_beta,
+    ModelScanner,
+    CommunityScanner,
+    AsyncModelScanner,
+    AsyncCommunityScanner,
+)
 from ._types import NOT_GIVEN, Omit, NoneType, NotGiven, Transport, ProxiesTypes, omit, not_given
 from ._utils import file_from_path
 from ._client import (
@@ -46,6 +53,8 @@ __all__ = [
     "__version__",
     "__title__",
     "NoneType",
+    "BetaWarning",
+    "warn_beta",
     "CommunityScanner",
     "AsyncCommunityScanner",
     "ModelScanner",

--- a/src/hiddenlayer/lib/__init__.py
+++ b/src/hiddenlayer/lib/__init__.py
@@ -1,9 +1,12 @@
 # Custom extensions for HiddenLayer SDK
+from ._beta import BetaWarning, warn_beta
 from .model_scan import ModelScanner, AsyncModelScanner
 from .community_scan import CommunityScanner, CommunityScanSource, AsyncCommunityScanner
 from .evaluation_sessions import EvaluationSessionsResource, AsyncEvaluationSessionsResource
 
 __all__ = [
+    "BetaWarning",
+    "warn_beta",
     "CommunityScanner",
     "AsyncCommunityScanner",
     "ModelScanner",

--- a/src/hiddenlayer/lib/_beta.py
+++ b/src/hiddenlayer/lib/_beta.py
@@ -1,0 +1,27 @@
+"""Runtime beta warning utility.
+
+Emits a warning when a beta endpoint is called, so SDK consumers know
+the method is not yet GA.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+
+class BetaWarning(UserWarning):
+    """Warning emitted when a beta API endpoint is called."""
+
+
+def warn_beta(qualified_name: str) -> None:
+    """Emit a warning that a beta endpoint was called.
+
+    Args:
+        qualified_name: Fully qualified method name, e.g. "InteractionsResource.analyze"
+    """
+    warnings.warn(
+        f"[BETA] {qualified_name}: This endpoint is not GA or Production ready "
+        "and is subject to changes at any time. Breaking changes may occur.",
+        BetaWarning,
+        stacklevel=3,
+    )

--- a/tests/test_beta.py
+++ b/tests/test_beta.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from hiddenlayer.lib._beta import BetaWarning, warn_beta
+
+
+class TestWarnBeta:
+    def test_emits_warning_on_call(self) -> None:
+        with pytest.warns(BetaWarning, match=r"\[BETA\] Foo\.firstCall"):
+            warn_beta("Foo.firstCall")
+
+    def test_warning_message_format(self) -> None:
+        with pytest.warns(BetaWarning) as record:
+            warn_beta("Bar.analyze")
+
+        assert len(record) == 1
+        assert "[BETA] Bar.analyze" in str(record[0].message)
+        assert "not GA or Production ready" in str(record[0].message)
+        assert "Breaking changes may occur" in str(record[0].message)
+
+    def test_warning_category_is_beta(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warn_beta("Baz.create")
+
+        assert len(caught) == 1
+        assert issubclass(caught[0].category, BetaWarning)
+        assert issubclass(caught[0].category, UserWarning)


### PR DESCRIPTION
Adds automatic runtime warnings for beta SDK methods, mirroring the TypeScript and Java SDK implementations.

## Changes
- `BetaWarning` class (subclass of `UserWarning`) for Python's warnings infrastructure
- `warn_beta()` utility that emits via `warnings.warn()` when beta endpoints are called
- CI patcher script (`scripts/utils/patch-beta-warnings.cjs`) that scans generated resource files for `[BETA]` in docstrings and injects `warn_beta()` calls
- GitHub Actions workflow to run the patcher automatically on pushes to `next`
- pytest filter to allow `BetaWarning` during tests without triggering the `filterwarnings = ["error"]` config
- Unit tests for the warning utility

## Related Issues
DIS-936

## Breaking Changes
None