### PR TITLE
fix(red_team_session): default prompt_set_id to omit sentinel

### DIFF
--- a/src/hiddenlayer/lib/red_team_session.py
+++ b/src/hiddenlayer/lib/red_team_session.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, Awaitable, AsyncItera
 
 import httpx
 
+from .._types import Omit, omit
 from .._resource import SyncAPIResource, AsyncAPIResource
 from ..types.evaluations import RedTeamCreateResponse, RedTeamRetrieveNextActionResponse
 from .red_team_exceptions import PollTimeoutError, InvalidSessionError, RedTeamSessionError, WorkflowNotFoundError
@@ -245,7 +246,7 @@ class RedTeamSessionsResource(SyncAPIResource):
             attacker_max_generation_attempts: int = 2,
             n_random_techniques: int = 1,
             max_parallel_techniques: int = 1,
-            prompt_set_id: str = "",
+            prompt_set_id: str | Omit = omit,
             hiddenlayer_project_id: str | None = None,
             poll_interval: float = 2.0,
             poll_max_wait: float | None = None,
@@ -774,7 +775,7 @@ class AsyncRedTeamSessionsResource(AsyncAPIResource):
             attacker_max_generation_attempts: int = 2,
             n_random_techniques: int = 1,
             max_parallel_techniques: int = 1,
-            prompt_set_id: str = "",
+            prompt_set_id: str | Omit = omit,
             hiddenlayer_project_id: str | None = None,
             poll_interval: float = 2.0,
             poll_max_wait: float | None = None,

--- a/tests/test_red_team_session.py
+++ b/tests/test_red_team_session.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from hiddenlayer import HiddenLayer, AsyncHiddenLayer
+from hiddenlayer._types import Omit
 from hiddenlayer.types.evaluations import RedTeamRetrieveNextActionResponse
 from hiddenlayer.lib.red_team_session import (
     RedTeamSession,
@@ -1314,6 +1315,30 @@ class TestRedTeamSessionsResourceStartSession:
                 execution_strategy_type="invalid_strategy",
             )
 
+    def test_start_session_omits_prompt_set_id_when_not_provided(
+        self, session_resource: RedTeamSessionsResource
+    ) -> None:
+        """prompt_set_id is a UUID server-side; forward the SDK omit sentinel when caller leaves it unset.
+
+        Regression test: previously the wrapper defaulted prompt_set_id to "" and forwarded
+        that empty string, causing the server to reject the request with "invalid UUID length: 0".
+        """
+        mock_response = Mock()
+        mock_response.workflow_id = "workflow-no-prompt-set"
+
+        session_resource._client.evaluations.red_team.create = Mock(
+            return_value=mock_response
+        )
+
+        session_resource.start_session(
+            name="test-session",
+            target_model="openai/gpt-4o",
+            objective_ids=["HLO.01"],
+        )
+
+        call_kwargs = session_resource._client.evaluations.red_team.create.call_args.kwargs
+        assert isinstance(call_kwargs["prompt_set_id"], Omit)
+
 
 class TestRedTeamSessionsResourceResumeSession:
     """Tests for RedTeamSessionsResource.resume_session method."""
@@ -1516,6 +1541,31 @@ class TestAsyncRedTeamSessionsResourceStartSession:
                 target_model="openai/gpt-4o",
                 execution_strategy_type="invalid_strategy",
             )
+
+    @pytest.mark.asyncio
+    async def test_start_session_omits_prompt_set_id_when_not_provided(
+        self, async_session_resource: AsyncRedTeamSessionsResource
+    ) -> None:
+        """prompt_set_id is a UUID server-side; forward the SDK omit sentinel when caller leaves it unset.
+
+        Regression test: previously the wrapper defaulted prompt_set_id to "" and forwarded
+        that empty string, causing the server to reject the request with "invalid UUID length: 0".
+        """
+        mock_response = Mock()
+        mock_response.workflow_id = "workflow-no-prompt-set"
+
+        async_session_resource._client.evaluations.red_team.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        await async_session_resource.start_session(
+            name="test-session",
+            target_model="openai/gpt-4o",
+            objective_ids=["HLO.01"],
+        )
+
+        call_kwargs = async_session_resource._client.evaluations.red_team.create.call_args.kwargs
+        assert isinstance(call_kwargs["prompt_set_id"], Omit)
 
 
 class TestAsyncRedTeamSessionsResourceResumeSession:


### PR DESCRIPTION
## Summary

The handrolled `start_session` wrappers in [`src/hiddenlayer/lib/red_team_session.py`](src/hiddenlayer/lib/red_team_session.py) defaulted `prompt_set_id` to `""` and forwarded it unconditionally to `evaluations.red_team.create(...)`. The server validates this field as a UUID and rejects empty strings:

```
400 Bad Request: {'title': 'Bad Request', 'detail': 'Request body is malformed JSON or has invalid types', 'errors': [{'code': 'request.malformed', 'detail': 'invalid UUID length: 0'}]}
```

This made every session that didn't explicitly pass a `prompt_set_id` unusable (e.g. all `execution_strategy_type="random"` and `"single"` runs).

## Fix

Mirror the generated resource's signature exactly. The generated `red_team.create` already declares `prompt_set_id: str | Omit = omit` and drops `omit` values from the request body. The wrapper just needs to do the same:

```python
from .._types import Omit, omit

def start_session(
    ...
    prompt_set_id: str | Omit = omit,   # was: str = ""
    ...
):
    ...
    resp = self._client.evaluations.red_team.create(
        ...
        prompt_set_id=prompt_set_id,   # forwards omit straight through
    )
```

Net change: 1 import line + 1 signature line per `(sync, async)` class. No conditional logic, no kwargs dict, no churn at the call site, and any future field added to `red_team.create` continues to flow via the existing named kwargs.

## Tests

- All existing `start_session` unit tests in `tests/test_red_team_session.py` still pass (`-k start_session` -> 8 passed).
- Added 2 new regression tests (sync + async): `test_start_session_omits_prompt_set_id_when_not_provided`, asserting `isinstance(call_kwargs["prompt_set_id"], Omit)` when the caller omits the field.

## End-to-end verification

Ran the [e2e-sdk-py](https://github.com/hiddenlayerai/e2e-sdk-py) red-team evaluation suite against staging with this branch installed editable. Before the fix all 5 tests failed at `start_session` with the UUID error; after the fix:

```
[gw0] PASSED test_async_parallel_evaluation
[gw1] PASSED test_async_sequential_evaluation
[gw2] PASSED test_async_workflow_termination
[gw3] PASSED test_sync_sequential_evaluation
[gw4] PASSED test_sync_workflow_termination
================== 5 passed, 5 warnings in 535.95s (0:08:55) ===================
```

## Out of scope (separate follow-up)

While reviewing I noticed that the `payload` dict in both `start_session` methods is built but never sent. Two side-effect bugs follow: `hiddenlayer_project_id` and `sessions_per_technique` are added to `payload` but never forwarded to `red_team.create(...)`, so they are silently dropped. Worth a separate PR.

## Test plan

- [ ] CI passes
- [ ] Reviewer confirms the wrapper signature now mirrors the generated `red_team.create` signature 1:1 for `prompt_set_id`
