### PR TITLE
feat(red-team): forward all start_session params and drop hardcoded defaults

### DIFF
--- a/api.md
+++ b/api.md
@@ -241,7 +241,7 @@ Accessed via `client.evaluation_sessions.red_team`.
 
 Methods:
 
-- **start_session(name, target_model, target_system_prompt="", max_turns=3, execution_strategy_type="random", attacker_max_generation_attempts=2, n_random_techniques=1, max_parallel_techniques=1, prompt_set_id="", hiddenlayer_project_id=None, poll_interval=2.0, poll_max_wait=None, sessions_per_technique=1) -> RedTeamSession**  
+- **start_session(name, target_model, target_system_prompt="", objective_ids=omit, refusal_judge_model=omit, objective_judge_model=omit, attacker_model=omit, evaluation_report_model=omit, attacker_guidance=omit, severity_mapping=omit, config_id=omit, max_turns=3, execution_strategy_type="random", attacker_max_generation_attempts=2, n_random_techniques=1, max_parallel_techniques=1, prompt_set_id=omit, hiddenlayer_project_id=None, poll_interval=2.0, poll_max_wait=None, sessions_per_technique=1) -> RedTeamSession**  
   Start a new red team session. Returns a `RedTeamSession` (sync) or `AsyncRedTeamSession` (async).
   Uses adaptive multi-objective evaluation: each session runs to `max_turns` (no short-circuit),
   tests all objectives, and maintains cross-session state for adaptive attacks.

--- a/src/hiddenlayer/lib/red_team_session.py
+++ b/src/hiddenlayer/lib/red_team_session.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import time
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Awaitable, AsyncIterator
+from typing import TYPE_CHECKING, Any, Dict, Callable, Iterator, Awaitable, AsyncIterator
+from typing_extensions import Literal
 
 import httpx
 
@@ -212,35 +213,23 @@ class RedTeamSession:
 
 
 class RedTeamSessionsResource(SyncAPIResource):
-    _available_objective_ids = ["HLO.01", "HLO.02", "HLO.03", "HLO.05", "HLO.07"]
-
-    def __init__(
-            self,
-            client: HiddenLayer,
-            *,
-            default_refusal_judge_model: str = "openai/gpt-5-mini",
-            default_objective_judge_model: str = "openai/gpt-5",
-            default_attacker_model: str = "openai/gpt-5",
-            default_evaluation_report_model: str = "openai/gpt-5",
-    ):
-        # Default models for red team evaluations
-        self._default_refusal_judge_model = default_refusal_judge_model
-        self._default_objective_judge_model = default_objective_judge_model
-        self._default_attacker_model = default_attacker_model
-        self._default_evaluation_report_model = default_evaluation_report_model
+    def __init__(self, client: HiddenLayer):
         super().__init__(client)
 
     def start_session(
             self,
             *,
             name: str,
-            objective_ids: list[str] | None = None,
+            objective_ids: list[str] | Omit = omit,
             target_model: str,
             target_system_prompt: str = "",
-            refusal_judge_model: str | None = None,
-            objective_judge_model: str | None = None,
-            attacker_model: str | None = None,
-            evaluation_report_model: str | None = None,
+            refusal_judge_model: str | Omit = omit,
+            objective_judge_model: str | Omit = omit,
+            attacker_model: str | Omit = omit,
+            evaluation_report_model: str | Omit = omit,
+            attacker_guidance: str | Omit = omit,
+            severity_mapping: Dict[str, Literal["CRITICAL", "HIGH", "MEDIUM", "LOW", "NONE"]] | Omit = omit,
+            config_id: str | Omit = omit,
             max_turns: int = 3,
             execution_strategy_type: str = "random",
             attacker_max_generation_attempts: int = 2,
@@ -260,17 +249,20 @@ class RedTeamSessionsResource(SyncAPIResource):
 
         Args:
             name: Session name
-            objective_ids: List of objective IDs to test (e.g., ["HLO.03"]).
-                Optional; defaults to all available objectives.
+            objective_ids: List of objective IDs to test (e.g., ["HLO.03"])
             target_model: Model identifier for the target being tested
             target_system_prompt: System prompt for the target model
             refusal_judge_model: Model to use for refusal judging
-                (defaults to client default)
             objective_judge_model: Model to use for objective judging
-                (defaults to client default)
-            attacker_model: Model to use for generating attacks (defaults to client default)
+            attacker_model: Model to use for generating attacks
             evaluation_report_model: Model to use for evaluation reports
-                (defaults to client default)
+            attacker_guidance: Optional intent-only natural-language text to focus the
+                attacker LLM within the configured objectives. No-op for the
+                static_prompt_set strategy.
+            severity_mapping: Map from objective ID to a severity level, used to derive
+                the per-session severity from the worst objective achieved.
+            config_id: Optional preset config to seed the workflow settings. Any field
+                also passed here overrides the corresponding value from the config.
             max_turns: Maximum conversation turns per session
             execution_strategy_type: Strategy type ("single", "random", or "static_prompt_set")
             attacker_max_generation_attempts: Max attempts for attacker to generate prompts
@@ -288,42 +280,11 @@ class RedTeamSessionsResource(SyncAPIResource):
         Raises:
             ValueError: If execution_strategy_type is invalid
         """
-        # Use defaults if not provided
-        refusal_judge_model = refusal_judge_model or self._default_refusal_judge_model
-        objective_judge_model = objective_judge_model or self._default_objective_judge_model
-        attacker_model = attacker_model or self._default_attacker_model
-        evaluation_report_model = evaluation_report_model or self._default_evaluation_report_model
-
-        # Default to all available objectives if not specified
-        if objective_ids is None:
-            objective_ids = self._available_objective_ids.copy()
-
         # Validate execution strategy
         if execution_strategy_type not in ["single", "random", "static_prompt_set"]:
             raise ValueError(
                 "execution_strategy_type must be 'single', 'random', or 'static_prompt_set'."
             )
-
-        payload = {
-            "name": name,
-            "target_system_prompt": target_system_prompt,
-            "objective_ids": objective_ids,
-            "target_model": target_model,
-            "refusal_judge_model": refusal_judge_model,
-            "objective_judge_model": objective_judge_model,
-            "attacker_model": attacker_model,
-            "evaluation_report_model": evaluation_report_model,
-            "execution_strategy_type": execution_strategy_type,
-            "max_turns": max_turns,
-            "attacker_max_generation_attempts": attacker_max_generation_attempts,
-            "n_random_techniques": n_random_techniques,
-            "max_parallel_techniques": max_parallel_techniques,
-            "prompt_set_id": prompt_set_id,
-        }
-        if hiddenlayer_project_id is not None:
-            payload["hl_project_id"] = hiddenlayer_project_id
-        if sessions_per_technique is not None:
-            payload["sessions_per_technique"] = sessions_per_technique
 
         resp: RedTeamCreateResponse = self._client.evaluations.red_team.create(
             name=name,
@@ -334,12 +295,17 @@ class RedTeamSessionsResource(SyncAPIResource):
             objective_judge_model=objective_judge_model,
             attacker_model=attacker_model,
             evaluation_report_model=evaluation_report_model,
+            attacker_guidance=attacker_guidance,
+            severity_mapping=severity_mapping,
+            config_id=config_id,
             execution_strategy_type=execution_strategy_type,
             max_turns=max_turns,
             attacker_max_generation_attempts=attacker_max_generation_attempts,
             n_random_techniques=n_random_techniques,
             max_parallel_techniques=max_parallel_techniques,
+            hl_project_id=hiddenlayer_project_id if hiddenlayer_project_id is not None else omit,
             prompt_set_id=prompt_set_id,
+            sessions_per_technique=sessions_per_technique if sessions_per_technique is not None else omit,
         )
         return RedTeamSession(
             client=self._client,
@@ -741,35 +707,23 @@ class AsyncRedTeamSession:
 
 
 class AsyncRedTeamSessionsResource(AsyncAPIResource):
-    _available_objective_ids = ["HLO.01", "HLO.02", "HLO.03", "HLO.05", "HLO.07"]
-
-    def __init__(
-            self,
-            client: AsyncHiddenLayer,
-            *,
-            default_refusal_judge_model: str = "openai/gpt-5-mini",
-            default_objective_judge_model: str = "openai/gpt-5",
-            default_attacker_model: str = "openai/gpt-5",
-            default_evaluation_report_model: str = "openai/gpt-5",
-    ):
-        # Default models for red team evaluations
-        self._default_refusal_judge_model = default_refusal_judge_model
-        self._default_objective_judge_model = default_objective_judge_model
-        self._default_attacker_model = default_attacker_model
-        self._default_evaluation_report_model = default_evaluation_report_model
+    def __init__(self, client: AsyncHiddenLayer):
         super().__init__(client)
 
     async def start_session(
             self,
             *,
             name: str,
-            objective_ids: list[str] | None = None,
+            objective_ids: list[str] | Omit = omit,
             target_model: str,
             target_system_prompt: str = "",
-            refusal_judge_model: str | None = None,
-            objective_judge_model: str | None = None,
-            attacker_model: str | None = None,
-            evaluation_report_model: str | None = None,
+            refusal_judge_model: str | Omit = omit,
+            objective_judge_model: str | Omit = omit,
+            attacker_model: str | Omit = omit,
+            evaluation_report_model: str | Omit = omit,
+            attacker_guidance: str | Omit = omit,
+            severity_mapping: Dict[str, Literal["CRITICAL", "HIGH", "MEDIUM", "LOW", "NONE"]] | Omit = omit,
+            config_id: str | Omit = omit,
             max_turns: int = 3,
             execution_strategy_type: str = "random",
             attacker_max_generation_attempts: int = 2,
@@ -789,17 +743,20 @@ class AsyncRedTeamSessionsResource(AsyncAPIResource):
 
         Args:
             name: Session name
-            objective_ids: List of objective IDs to test (e.g., ["HLO.03"]).
-                Optional; defaults to all available objectives.
+            objective_ids: List of objective IDs to test (e.g., ["HLO.03"])
             target_model: Model identifier for the target being tested
             target_system_prompt: System prompt for the target model
             refusal_judge_model: Model to use for refusal judging
-                (defaults to client default)
             objective_judge_model: Model to use for objective judging
-                (defaults to client default)
-            attacker_model: Model to use for generating attacks (defaults to client default)
+            attacker_model: Model to use for generating attacks
             evaluation_report_model: Model to use for evaluation reports
-                (defaults to client default)
+            attacker_guidance: Optional intent-only natural-language text to focus the
+                attacker LLM within the configured objectives. No-op for the
+                static_prompt_set strategy.
+            severity_mapping: Map from objective ID to a severity level, used to derive
+                the per-session severity from the worst objective achieved.
+            config_id: Optional preset config to seed the workflow settings. Any field
+                also passed here overrides the corresponding value from the config.
             max_turns: Maximum conversation turns per session
             execution_strategy_type: Strategy type ("single", "random", or "static_prompt_set")
             attacker_max_generation_attempts: Max attempts for attacker to generate prompts
@@ -817,42 +774,11 @@ class AsyncRedTeamSessionsResource(AsyncAPIResource):
         Raises:
             ValueError: If execution_strategy_type is invalid
         """
-        # Use defaults if not provided
-        refusal_judge_model = refusal_judge_model or self._default_refusal_judge_model
-        objective_judge_model = objective_judge_model or self._default_objective_judge_model
-        attacker_model = attacker_model or self._default_attacker_model
-        evaluation_report_model = evaluation_report_model or self._default_evaluation_report_model
-
-        # Default to all available objectives if not specified
-        if objective_ids is None:
-            objective_ids = self._available_objective_ids.copy()
-
         # Validate execution strategy
         if execution_strategy_type not in ["single", "random", "static_prompt_set"]:
             raise ValueError(
                 "execution_strategy_type must be 'single', 'random', or 'static_prompt_set'."
             )
-
-        payload = {
-            "name": name,
-            "target_system_prompt": target_system_prompt,
-            "objective_ids": objective_ids,
-            "target_model": target_model,
-            "refusal_judge_model": refusal_judge_model,
-            "objective_judge_model": objective_judge_model,
-            "attacker_model": attacker_model,
-            "evaluation_report_model": evaluation_report_model,
-            "execution_strategy_type": execution_strategy_type,
-            "max_turns": max_turns,
-            "attacker_max_generation_attempts": attacker_max_generation_attempts,
-            "n_random_techniques": n_random_techniques,
-            "max_parallel_techniques": max_parallel_techniques,
-            "prompt_set_id": prompt_set_id,
-        }
-        if hiddenlayer_project_id is not None:
-            payload["hl_project_id"] = hiddenlayer_project_id
-        if sessions_per_technique is not None:
-            payload["sessions_per_technique"] = sessions_per_technique
 
         resp: RedTeamCreateResponse = await self._client.evaluations.red_team.create(
             name=name,
@@ -863,12 +789,17 @@ class AsyncRedTeamSessionsResource(AsyncAPIResource):
             objective_judge_model=objective_judge_model,
             attacker_model=attacker_model,
             evaluation_report_model=evaluation_report_model,
+            attacker_guidance=attacker_guidance,
+            severity_mapping=severity_mapping,
+            config_id=config_id,
             execution_strategy_type=execution_strategy_type,
             max_turns=max_turns,
             attacker_max_generation_attempts=attacker_max_generation_attempts,
             n_random_techniques=n_random_techniques,
             max_parallel_techniques=max_parallel_techniques,
+            hl_project_id=hiddenlayer_project_id if hiddenlayer_project_id is not None else omit,
             prompt_set_id=prompt_set_id,
+            sessions_per_technique=sessions_per_technique if sessions_per_technique is not None else omit,
         )
         return AsyncRedTeamSession(
             client=self._client,

--- a/src/hiddenlayer/lib/red_team_session.py
+++ b/src/hiddenlayer/lib/red_team_session.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Callable, Iterator, Awaitable, AsyncIterator
+from typing import TYPE_CHECKING, Any, Dict, Callable, Iterator, Awaitable, AsyncIterator, cast
 from typing_extensions import Literal
 
 import httpx
@@ -285,6 +285,11 @@ class RedTeamSessionsResource(SyncAPIResource):
             raise ValueError(
                 "execution_strategy_type must be 'single', 'random', or 'static_prompt_set'."
             )
+        # The API enum is UPPER_SNAKE_CASE; callers may pass lowercase.
+        wire_execution_strategy_type = cast(
+            Literal["RANDOM", "SINGLE", "STATIC_PROMPT_SET"],
+            execution_strategy_type.upper(),
+        )
 
         resp: RedTeamCreateResponse = self._client.evaluations.red_team.create(
             name=name,
@@ -298,7 +303,7 @@ class RedTeamSessionsResource(SyncAPIResource):
             attacker_guidance=attacker_guidance,
             severity_mapping=severity_mapping,
             config_id=config_id,
-            execution_strategy_type=execution_strategy_type,
+            execution_strategy_type=wire_execution_strategy_type,
             max_turns=max_turns,
             attacker_max_generation_attempts=attacker_max_generation_attempts,
             n_random_techniques=n_random_techniques,
@@ -779,6 +784,11 @@ class AsyncRedTeamSessionsResource(AsyncAPIResource):
             raise ValueError(
                 "execution_strategy_type must be 'single', 'random', or 'static_prompt_set'."
             )
+        # The API enum is UPPER_SNAKE_CASE; callers may pass lowercase.
+        wire_execution_strategy_type = cast(
+            Literal["RANDOM", "SINGLE", "STATIC_PROMPT_SET"],
+            execution_strategy_type.upper(),
+        )
 
         resp: RedTeamCreateResponse = await self._client.evaluations.red_team.create(
             name=name,
@@ -792,7 +802,7 @@ class AsyncRedTeamSessionsResource(AsyncAPIResource):
             attacker_guidance=attacker_guidance,
             severity_mapping=severity_mapping,
             config_id=config_id,
-            execution_strategy_type=execution_strategy_type,
+            execution_strategy_type=wire_execution_strategy_type,
             max_turns=max_turns,
             attacker_max_generation_attempts=attacker_max_generation_attempts,
             n_random_techniques=n_random_techniques,

--- a/tests/test_red_team_session.py
+++ b/tests/test_red_team_session.py
@@ -1259,7 +1259,7 @@ class TestRedTeamSessionsResourceStartSession:
         assert call_kwargs["severity_mapping"] == {"HLO.01": "HIGH", "HLO.03": "CRITICAL"}
         assert call_kwargs["config_id"] == "config-abc-123"
         assert call_kwargs["max_turns"] == 7
-        assert call_kwargs["execution_strategy_type"] == "random"
+        assert call_kwargs["execution_strategy_type"] == "RANDOM"
         assert call_kwargs["attacker_max_generation_attempts"] == 3
         assert call_kwargs["n_random_techniques"] == 2
         assert call_kwargs["max_parallel_techniques"] == 4
@@ -1515,7 +1515,7 @@ class TestAsyncRedTeamSessionsResourceStartSession:
         assert call_kwargs["severity_mapping"] == {"HLO.01": "HIGH", "HLO.03": "CRITICAL"}
         assert call_kwargs["config_id"] == "config-abc-123"
         assert call_kwargs["max_turns"] == 7
-        assert call_kwargs["execution_strategy_type"] == "random"
+        assert call_kwargs["execution_strategy_type"] == "RANDOM"
         assert call_kwargs["attacker_max_generation_attempts"] == 3
         assert call_kwargs["n_random_techniques"] == 2
         assert call_kwargs["max_parallel_techniques"] == 4

--- a/tests/test_red_team_session.py
+++ b/tests/test_red_team_session.py
@@ -1221,12 +1221,16 @@ class TestRedTeamSessionsResourceStartSession:
             objective_judge_model="anthropic/claude-opus-4-1",
             attacker_model="openai/gpt-5",
             evaluation_report_model="openai/gpt-5-mini",
+            attacker_guidance="try to get the model to leak its system prompt",
+            severity_mapping={"HLO.01": "HIGH", "HLO.03": "CRITICAL"},
+            config_id="config-abc-123",
             max_turns=7,
             execution_strategy_type="random",
             attacker_max_generation_attempts=3,
             n_random_techniques=2,
             max_parallel_techniques=4,
             prompt_set_id="prompt-set-123",
+            hiddenlayer_project_id="project-xyz",
             poll_interval=1.5,
             poll_max_wait=90.0,
             sessions_per_technique=3,
@@ -1251,17 +1255,22 @@ class TestRedTeamSessionsResourceStartSession:
         assert call_kwargs["objective_judge_model"] == "anthropic/claude-opus-4-1"
         assert call_kwargs["attacker_model"] == "openai/gpt-5"
         assert call_kwargs["evaluation_report_model"] == "openai/gpt-5-mini"
+        assert call_kwargs["attacker_guidance"] == "try to get the model to leak its system prompt"
+        assert call_kwargs["severity_mapping"] == {"HLO.01": "HIGH", "HLO.03": "CRITICAL"}
+        assert call_kwargs["config_id"] == "config-abc-123"
         assert call_kwargs["max_turns"] == 7
         assert call_kwargs["execution_strategy_type"] == "random"
         assert call_kwargs["attacker_max_generation_attempts"] == 3
         assert call_kwargs["n_random_techniques"] == 2
         assert call_kwargs["max_parallel_techniques"] == 4
         assert call_kwargs["prompt_set_id"] == "prompt-set-123"
+        assert call_kwargs["hl_project_id"] == "project-xyz"
+        assert call_kwargs["sessions_per_technique"] == 3
 
-    def test_start_session_uses_all_objectives_when_none_provided(
+    def test_start_session_omits_objectives_when_none_provided(
         self, session_resource: RedTeamSessionsResource
     ) -> None:
-        """Test that start_session uses all available objectives when objective_ids is None."""
+        """start_session forwards omit for objective_ids so the service decides."""
         mock_response = Mock()
         mock_response.workflow_id = "workflow-default-objectives"
 
@@ -1272,17 +1281,16 @@ class TestRedTeamSessionsResourceStartSession:
         session_resource.start_session(
             name="test-session",
             target_model="openai/gpt-4o",
-            # objective_ids not provided - should default to all available
+            # objective_ids not provided - should forward omit
         )
 
-        # Verify API was called with all available objectives
         call_kwargs = session_resource._client.evaluations.red_team.create.call_args.kwargs
-        assert call_kwargs["objective_ids"] == ["HLO.01", "HLO.02", "HLO.03", "HLO.05", "HLO.07"]
+        assert isinstance(call_kwargs["objective_ids"], Omit)
 
-    def test_start_session_uses_default_models_when_not_provided(
+    def test_start_session_omits_models_when_not_provided(
         self, session_resource: RedTeamSessionsResource
     ) -> None:
-        """Test that start_session uses default models when not explicitly provided."""
+        """start_session forwards omit for judge/attacker models so the service defaults apply."""
         mock_response = Mock()
         mock_response.workflow_id = "workflow-default-models"
 
@@ -1294,15 +1302,39 @@ class TestRedTeamSessionsResourceStartSession:
             name="test-session",
             target_model="openai/gpt-4o",
             objective_ids=["HLO.01"],
-            # Model parameters not provided - should use defaults
+            # Model parameters not provided - should forward omit
         )
 
-        # Verify API was called with default models
         call_kwargs = session_resource._client.evaluations.red_team.create.call_args.kwargs
-        assert call_kwargs["refusal_judge_model"] == "openai/gpt-5-mini"
-        assert call_kwargs["objective_judge_model"] == "openai/gpt-5"
-        assert call_kwargs["attacker_model"] == "openai/gpt-5"
-        assert call_kwargs["evaluation_report_model"] == "openai/gpt-5"
+        assert isinstance(call_kwargs["refusal_judge_model"], Omit)
+        assert isinstance(call_kwargs["objective_judge_model"], Omit)
+        assert isinstance(call_kwargs["attacker_model"], Omit)
+        assert isinstance(call_kwargs["evaluation_report_model"], Omit)
+
+    def test_start_session_omits_optional_params_when_not_provided(
+        self, session_resource: RedTeamSessionsResource
+    ) -> None:
+        """New optional params and hl_project_id forward omit when the caller leaves them unset."""
+        mock_response = Mock()
+        mock_response.workflow_id = "workflow-omit-optional"
+
+        session_resource._client.evaluations.red_team.create = Mock(
+            return_value=mock_response
+        )
+
+        session_resource.start_session(
+            name="test-session",
+            target_model="openai/gpt-4o",
+            objective_ids=["HLO.01"],
+            sessions_per_technique=None,
+        )
+
+        call_kwargs = session_resource._client.evaluations.red_team.create.call_args.kwargs
+        assert isinstance(call_kwargs["attacker_guidance"], Omit)
+        assert isinstance(call_kwargs["severity_mapping"], Omit)
+        assert isinstance(call_kwargs["config_id"], Omit)
+        assert isinstance(call_kwargs["hl_project_id"], Omit)
+        assert isinstance(call_kwargs["sessions_per_technique"], Omit)
 
     def test_start_session_raises_on_invalid_execution_strategy(
         self, session_resource: RedTeamSessionsResource
@@ -1445,12 +1477,16 @@ class TestAsyncRedTeamSessionsResourceStartSession:
             objective_judge_model="anthropic/claude-opus-4-1",
             attacker_model="openai/gpt-5",
             evaluation_report_model="openai/gpt-5-mini",
+            attacker_guidance="try to get the model to leak its system prompt",
+            severity_mapping={"HLO.01": "HIGH", "HLO.03": "CRITICAL"},
+            config_id="config-abc-123",
             max_turns=7,
             execution_strategy_type="random",
             attacker_max_generation_attempts=3,
             n_random_techniques=2,
             max_parallel_techniques=4,
             prompt_set_id="prompt-set-123",
+            hiddenlayer_project_id="project-xyz",
             poll_interval=1.5,
             poll_max_wait=90.0,
             sessions_per_technique=3,
@@ -1475,18 +1511,23 @@ class TestAsyncRedTeamSessionsResourceStartSession:
         assert call_kwargs["objective_judge_model"] == "anthropic/claude-opus-4-1"
         assert call_kwargs["attacker_model"] == "openai/gpt-5"
         assert call_kwargs["evaluation_report_model"] == "openai/gpt-5-mini"
+        assert call_kwargs["attacker_guidance"] == "try to get the model to leak its system prompt"
+        assert call_kwargs["severity_mapping"] == {"HLO.01": "HIGH", "HLO.03": "CRITICAL"}
+        assert call_kwargs["config_id"] == "config-abc-123"
         assert call_kwargs["max_turns"] == 7
         assert call_kwargs["execution_strategy_type"] == "random"
         assert call_kwargs["attacker_max_generation_attempts"] == 3
         assert call_kwargs["n_random_techniques"] == 2
         assert call_kwargs["max_parallel_techniques"] == 4
         assert call_kwargs["prompt_set_id"] == "prompt-set-123"
+        assert call_kwargs["hl_project_id"] == "project-xyz"
+        assert call_kwargs["sessions_per_technique"] == 3
 
     @pytest.mark.asyncio
-    async def test_start_session_uses_all_objectives_when_none_provided(
+    async def test_start_session_omits_objectives_when_none_provided(
         self, async_session_resource: AsyncRedTeamSessionsResource
     ) -> None:
-        """Test that start_session uses all available objectives when objective_ids is None."""
+        """start_session forwards omit for objective_ids so the service decides."""
         mock_response = Mock()
         mock_response.workflow_id = "workflow-default-objectives"
 
@@ -1497,18 +1538,17 @@ class TestAsyncRedTeamSessionsResourceStartSession:
         await async_session_resource.start_session(
             name="test-session",
             target_model="openai/gpt-4o",
-            # objective_ids not provided - should default to all available
+            # objective_ids not provided - should forward omit
         )
 
-        # Verify API was called with all available objectives
         call_kwargs = async_session_resource._client.evaluations.red_team.create.call_args.kwargs
-        assert call_kwargs["objective_ids"] == ["HLO.01", "HLO.02", "HLO.03", "HLO.05", "HLO.07"]
+        assert isinstance(call_kwargs["objective_ids"], Omit)
 
     @pytest.mark.asyncio
-    async def test_start_session_uses_default_models_when_not_provided(
+    async def test_start_session_omits_models_when_not_provided(
         self, async_session_resource: AsyncRedTeamSessionsResource
     ) -> None:
-        """Test that start_session uses default models when not explicitly provided."""
+        """start_session forwards omit for judge/attacker models so the service defaults apply."""
         mock_response = Mock()
         mock_response.workflow_id = "workflow-default-models"
 
@@ -1520,15 +1560,40 @@ class TestAsyncRedTeamSessionsResourceStartSession:
             name="test-session",
             target_model="openai/gpt-4o",
             objective_ids=["HLO.01"],
-            # Model parameters not provided - should use defaults
+            # Model parameters not provided - should forward omit
         )
 
-        # Verify API was called with default models
         call_kwargs = async_session_resource._client.evaluations.red_team.create.call_args.kwargs
-        assert call_kwargs["refusal_judge_model"] == "openai/gpt-5-mini"
-        assert call_kwargs["objective_judge_model"] == "openai/gpt-5"
-        assert call_kwargs["attacker_model"] == "openai/gpt-5"
-        assert call_kwargs["evaluation_report_model"] == "openai/gpt-5"
+        assert isinstance(call_kwargs["refusal_judge_model"], Omit)
+        assert isinstance(call_kwargs["objective_judge_model"], Omit)
+        assert isinstance(call_kwargs["attacker_model"], Omit)
+        assert isinstance(call_kwargs["evaluation_report_model"], Omit)
+
+    @pytest.mark.asyncio
+    async def test_start_session_omits_optional_params_when_not_provided(
+        self, async_session_resource: AsyncRedTeamSessionsResource
+    ) -> None:
+        """New optional params and hl_project_id forward omit when the caller leaves them unset."""
+        mock_response = Mock()
+        mock_response.workflow_id = "workflow-omit-optional"
+
+        async_session_resource._client.evaluations.red_team.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        await async_session_resource.start_session(
+            name="test-session",
+            target_model="openai/gpt-4o",
+            objective_ids=["HLO.01"],
+            sessions_per_technique=None,
+        )
+
+        call_kwargs = async_session_resource._client.evaluations.red_team.create.call_args.kwargs
+        assert isinstance(call_kwargs["attacker_guidance"], Omit)
+        assert isinstance(call_kwargs["severity_mapping"], Omit)
+        assert isinstance(call_kwargs["config_id"], Omit)
+        assert isinstance(call_kwargs["hl_project_id"], Omit)
+        assert isinstance(call_kwargs["sessions_per_technique"], Omit)
 
     @pytest.mark.asyncio
     async def test_start_session_raises_on_invalid_execution_strategy(


### PR DESCRIPTION
## Summary
- Bring the hand-written `start_session` wrapper in `src/hiddenlayer/lib/red_team_session.py` to parity with the generated `red_team.create()` (both sync `RedTeamSessionsResource` and async `AsyncRedTeamSessionsResource`).
- Remove the hardcoded model defaults (`openai/gpt-5*`) and the built-in `objective_ids` list; these are now omitted so the service applies its own defaults.
- Forward `attacker_guidance`, `severity_mapping`, and `config_id`, which the wrapper previously never passed through.
- Fix `hl_project_id` and `sessions_per_technique`, which were only written into a dead `payload` dict and silently dropped before reaching `create()`.
- Update `tests/test_red_team_session.py` and the `start_session` signature in `api.md` accordingly.

## Test plan
- [x] `pytest tests/test_red_team_session.py` -> 56 passed