### PR TITLE
fix(ci): clone and build release-please fork from source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,13 @@ jobs:
           node-version: '20'
 
       - name: Install release-please
-        run: npm install -g "git+https://github.com/stainless-api/release-please.git#a116e1e520e0f87824acf46a2e79c91d41e819d7"
+        run: |
+          git clone https://github.com/stainless-api/release-please.git /tmp/release-please
+          cd /tmp/release-please
+          git checkout a116e1e520e0f87824acf46a2e79c91d41e819d7
+          npm install
+          npm run build
+          npm link
 
       - name: Create or update release PR
         env:
@@ -54,7 +60,13 @@ jobs:
           node-version: '20'
 
       - name: Install release-please
-        run: npm install -g "git+https://github.com/stainless-api/release-please.git#a116e1e520e0f87824acf46a2e79c91d41e819d7"
+        run: |
+          git clone https://github.com/stainless-api/release-please.git /tmp/release-please
+          cd /tmp/release-please
+          git checkout a116e1e520e0f87824acf46a2e79c91d41e819d7
+          npm install
+          npm run build
+          npm link
 
       - name: Create GitHub release
         id: gh-release


### PR DESCRIPTION
## Summary

- `npm install -g` from a git URL skips devDependencies, so the fork's `prepare` script (`tsc`) fails because `gts` is missing.
- Clone at the pinned SHA, `npm install` (with devDeps), `npm run build`, and `npm link` instead.

## Test plan

- [ ] Release workflow's install step succeeds
- [ ] `release-please release-pr` runs successfully