### PR TITLE
fix(ci): build release-please fork from source with forced emit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install release-please
         run: |
@@ -32,7 +32,7 @@ jobs:
           cd /tmp/release-please
           git checkout a116e1e520e0f87824acf46a2e79c91d41e819d7
           npm install
-          npm run build
+          npx tsc --project tsconfig.json --skipLibCheck --noEmitOnError false
           npm link
 
       - name: Create or update release PR
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install release-please
         run: |
@@ -65,7 +65,7 @@ jobs:
           cd /tmp/release-please
           git checkout a116e1e520e0f87824acf46a2e79c91d41e819d7
           npm install
-          npm run build
+          npx tsc --project tsconfig.json --skipLibCheck --noEmitOnError false
           npm link
 
       - name: Create GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '18'
 
       - name: Install release-please
         run: |
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '18'
 
       - name: Install release-please
         run: |


### PR DESCRIPTION
## Summary

- `npm install -g` from a git URL runs the fork's `prepare` script (`tsc`), which fails because devDependencies (like `gts`) aren't installed in a global context.
- The fork has no lockfile and no prebuilt output, so building from source is the only option.
- Even with devDependencies installed, `tsc` fails due to Octokit type drift (the fork's `@octokit/plugin-paginate-rest` types have diverged from `@octokit/types`). These are purely type-checker errors that don't affect the emitted JavaScript.
- Fix: clone at the pinned SHA, `npm install`, then build with `--skipLibCheck --noEmitOnError false` to force emit despite the type errors. `npm link` makes the binary available on PATH.

## Test plan

- [ ] Release workflow install step succeeds
- [ ] `release-please release-pr` runs and opens/updates a release PR against `main`