### PR TITLE
fix(ci): use pnpm with the fork's lockfile instead of npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,9 @@ jobs:
           git clone https://github.com/stainless-api/release-please.git /tmp/release-please
           cd /tmp/release-please
           git checkout a116e1e520e0f87824acf46a2e79c91d41e819d7
-          npm install
-          npx tsc --project tsconfig.json --skipLibCheck --noEmitOnError false
+          corepack enable
+          pnpm install
+          pnpm run build
           npm link
 
       - name: Create or update release PR
@@ -64,8 +65,9 @@ jobs:
           git clone https://github.com/stainless-api/release-please.git /tmp/release-please
           cd /tmp/release-please
           git checkout a116e1e520e0f87824acf46a2e79c91d41e819d7
-          npm install
-          npx tsc --project tsconfig.json --skipLibCheck --noEmitOnError false
+          corepack enable
+          pnpm install
+          pnpm run build
           npm link
 
       - name: Create GitHub release


### PR DESCRIPTION
## Summary

The release-please fork uses pnpm and ships a `pnpm-lock.yaml`. The previous install used `npm install`, which ignores the lockfile and resolves latest-compatible transitive dependencies — causing Octokit type drift that breaks `tsc`.

Switches to the fork's actual build process: `corepack enable`, `pnpm install` (respects the lockfile), `pnpm run build`, `npm link`.

Validated locally — clean build, zero errors, binary runs.

## Test plan

- [ ] Release workflow install step succeeds
- [ ] `release-please release-pr` opens/updates a release PR against `main`